### PR TITLE
hotfix: change cargo version to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sachy"
 version = "0.1.0"
-edition = "2023"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Pull Request Description
This PR changes the Cargo.toml cargo edition from 2023 to 2021.

## Motivation and Context
2023 is not a valid cargo edition

## Checklist
Please review and check the following before merging this pull request:

- [x] The code follows the project's code style guidelines.
- [x] All existing tests pass successfully.
- [x] New tests have been added to cover the changes introduced.
- [x] Documentation has been updated (if applicable).
- [x] The changes are properly formatted and free of linting errors.
- [x] The commit message follows the project's commit message conventions.

## Testing Instructions
N/A

## Screenshots (if applicable)
N/A

## Additional Notes
N/A